### PR TITLE
Include support for Neovim's TextYankPost

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Make the yanked region apparent!
 map y <Plug>(highlightedyank)
 ```
 
+If you use Neovim, there is no need for configuration, as the highlight event is automatically triggered by the TextYankPost event.
+
 If you want to optimize highlight duration, use `g:highlightedyank_highlight_duration` , `b:highlightedyank_highlight_duration`. Assign number of time in milli seconds.
 ```vim
 let g:highlightedyank_highlight_duration = 1000

--- a/autoload/highlightedyank.vim
+++ b/autoload/highlightedyank.vim
@@ -90,8 +90,23 @@ function! highlightedyank#autocmd_highlight() abort "{{{
   let region = {}
   let region.head = getpos("'[")
   let region.tail = getpos("']")
-  let motionwise = 'char'
+  let char = getline(region.tail[1])[region.tail[2] - 1]
+  let linecontent = v:event.regcontents[len(v:event.regcontents) - 1]
+  let tailchar = linecontent[len(linecontent) - 1]
+  if char != tailchar
+    let region.tail[2] = region.tail[2] - 1
+  endif
+  if v:event.regtype == 'v'
+    let motionwise = 'char'
+  elseif v:event.regtype == 'V'
+    let motionwise = 'line'
+  elseif v:event.regtype =~ "\<c-v>"
+    let motionwise = 'block'
+  else
+    let motionwise = ''
+  endif
   if motionwise !=# ''
+    call s:modify_region(region)
     let hi_group = 'HighlightedyankRegion'
     let hi_duration = s:get('highlight_duration', 1000)
 
@@ -118,6 +133,7 @@ function! highlightedyank#autocmd_highlight() abort "{{{
     normal! :
   endif
 endfunction
+"}}}
 function! s:yank_visual(register) abort "{{{
   let view = winsaveview()
   let region = {}

--- a/autoload/highlightedyank.vim
+++ b/autoload/highlightedyank.vim
@@ -85,6 +85,39 @@ function! s:yank_normal(count, register) abort "{{{
   endif
 endfunction
 "}}}
+function! highlightedyank#autocmd_highlight() abort "{{{
+  let view = winsaveview()
+  let region = {}
+  let region.head = getpos("'[")
+  let region.tail = getpos("']")
+  let motionwise = 'char'
+  if motionwise !=# ''
+    let hi_group = 'HighlightedyankRegion'
+    let hi_duration = s:get('highlight_duration', 1000)
+
+    let errmsg = ''
+    let options = s:shift_options()
+    try
+      let highlight = highlightedyank#highlight#new()
+      call highlight.order(region, motionwise)
+      if hi_duration < 0
+        call s:persist(highlight, hi_group)
+      elseif hi_duration > 0
+        call {s:highlight_func}(highlight, hi_group, hi_duration)
+      endif
+    catch
+      let errmsg = printf('highlightedyank: Unanticipated error. [%s] %s', v:throwpoint, v:exception)
+    finally
+      call s:restore_options(options)
+
+      if errmsg !=# ''
+        echoerr errmsg
+      endif
+    endtry
+  else
+    normal! :
+  endif
+endfunction
 function! s:yank_visual(register) abort "{{{
   let view = winsaveview()
   let region = {}
@@ -370,7 +403,6 @@ function! s:is_equal_or_ahead(pos1, pos2) abort  "{{{
   return a:pos1[1] > a:pos2[1] || (a:pos1[1] == a:pos2[1] && a:pos1[2] >= a:pos2[2])
 endfunction
 "}}}
-
 
 " vim:set foldmethod=marker:
 " vim:set commentstring="%s:

--- a/autoload/highlightedyank.vim
+++ b/autoload/highlightedyank.vim
@@ -96,14 +96,9 @@ function! highlightedyank#autocmd_highlight() abort "{{{
   if char != tailchar
     let region.tail[2] = region.tail[2] - 1
   endif
-  if v:event.regtype == 'v'
-    let motionwise = 'char'
-  elseif v:event.regtype == 'V'
-    let motionwise = 'line'
-  elseif v:event.regtype =~ "\<c-v>"
+  let motionwise = v:event.regtype
+  if motionwise =~ "\<c-v>"
     let motionwise = 'block'
-  else
-    let motionwise = ''
   endif
   if motionwise !=# ''
     call s:modify_region(region)

--- a/doc/tags-ja
+++ b/doc/tags-ja
@@ -1,9 +1,0 @@
-!_TAG_FILE_ENCODING	utf-8	//
-b:highlightedyank_highlight_duration	highlightedyank.jax	/*b:highlightedyank_highlight_duration*
-g:highlightedyank_highlight_duration	highlightedyank.jax	/*g:highlightedyank_highlight_duration*
-highlightedyank-highlight-groups	highlightedyank.jax	/*highlightedyank-highlight-groups*
-highlightedyank-index	highlightedyank.jax	/*highlightedyank-index*
-highlightedyank-introduction	highlightedyank.jax	/*highlightedyank-introduction*
-highlightedyank.txt	highlightedyank.jax	/*highlightedyank.txt*
-highlightedyank.vim	highlightedyank.jax	/*highlightedyank.vim*
-hl-HighlightedyankRegion	highlightedyank.jax	/*hl-HighlightedyankRegion*

--- a/doc/tags-ja
+++ b/doc/tags-ja
@@ -1,0 +1,9 @@
+!_TAG_FILE_ENCODING	utf-8	//
+b:highlightedyank_highlight_duration	highlightedyank.jax	/*b:highlightedyank_highlight_duration*
+g:highlightedyank_highlight_duration	highlightedyank.jax	/*g:highlightedyank_highlight_duration*
+highlightedyank-highlight-groups	highlightedyank.jax	/*highlightedyank-highlight-groups*
+highlightedyank-index	highlightedyank.jax	/*highlightedyank-index*
+highlightedyank-introduction	highlightedyank.jax	/*highlightedyank-introduction*
+highlightedyank.txt	highlightedyank.jax	/*highlightedyank.txt*
+highlightedyank.vim	highlightedyank.jax	/*highlightedyank.vim*
+hl-HighlightedyankRegion	highlightedyank.jax	/*hl-HighlightedyankRegion*

--- a/plugin/highlightedyank.vim
+++ b/plugin/highlightedyank.vim
@@ -26,3 +26,6 @@ noremap <Plug>(highlightedyank-y) y
 noremap <Plug>(highlightedyank-g@) g@
 noremap <Plug>(highlightedyank-doublequote) "
 
+if exists('##TextYankPost') && !exists('g:highlightedyank_disable_autocmd')
+  autocmd neoyank TextYankPost * silent call highlightedyank#autocmd_highlight()
+endif


### PR DESCRIPTION
Hello.

I really like this plugin functionality, but I don't like the fact that you have to remap the y operator.

Therefore, to solve my use case, I've included support the Neovim's [TextYankPost](https://neovim.io/doc/user/autocmd.html#TextYankPost) event, which allows highlightedyank to work without fussing around with remaps. Do you think it could be useful to other users of the project?
