### PR TITLE
Error detected while processing function <SNR>393_scheduled_quench

### DIFF
--- a/autoload/highlightedyank/highlight.vim
+++ b/autoload/highlightedyank/highlight.vim
@@ -167,7 +167,7 @@ function! s:scheduled_quench(id) abort  "{{{
   finally
     unlet s:quench_table[a:id]
     call s:metabolize_augroup(a:id)
-    call timer_stop(id)
+    call timer_stop(a:id)
     call s:restore_options(options)
     redraw
   endtry


### PR DESCRIPTION
I'm using NeoVim 0.1.5 where `normal! yy` started giving me an error today:

```
Error detected while processing function <SNR>393_scheduled_quench:
line   15:
E121: Undefined variable: id
Press ENTER or type command to continue
Error detected while processing function <SNR>393_scheduled_quench:
line   15:
E116: Invalid arguments for function timer_stop
Press ENTER or type command to continue
```