### PR TITLE
fix " register saving

### DIFF
--- a/autoload/highlightedyank.vim
+++ b/autoload/highlightedyank.vim
@@ -61,7 +61,7 @@ function! s:yank_normal(count, register) abort "{{{
     if region != s:null_region
       call s:highlight_yanked_region(region)
       let keyseq = printf('%s%s%s%s', a:register, a:count, s:normal['y'], input)
-      call feedkeys(keyseq, 'it')
+      call feedkeys(keyseq, 'itx')
     endif
   finally
     call winrestview(view)
@@ -86,7 +86,7 @@ function! s:yank_visual(register) abort "{{{
   try
     call s:highlight_yanked_region(region)
     let keyseq = printf('%s%s%s', s:normal['gv'], a:register, s:normal['y'])
-    call feedkeys(keyseq, 'it')
+    call feedkeys(keyseq, 'itx')
   finally
     call winrestview(view)
     call s:restore_options(options)

--- a/autoload/highlightedyank/highlight.vim
+++ b/autoload/highlightedyank/highlight.vim
@@ -418,19 +418,22 @@ function! s:get_buf_text(region, type) abort  "{{{
   let text = ''
   let visual = [getpos("'<"), getpos("'>")]
   let modified = [getpos("'["), getpos("']")]
-  let registers = s:saveregisters()
   let view = winsaveview()
+  let registers = []
   try
     call setpos('.', a:region.head)
     execute 'normal! ' . s:v(a:type)
     call setpos('.', a:region.tail)
     silent noautocmd normal! ""y
+    let registers = s:saveregisters()
     let text = @@
 
     " NOTE: This line is required to reset v:register.
     normal! :
   finally
-    call s:restoreregisters(registers)
+    if len(registers) > 0
+        call s:restoreregisters(registers)
+    endif
     call setpos("'<", visual[0])
     call setpos("'>", visual[1])
     call setpos("'[", modified[0])


### PR DESCRIPTION
It conflicted with the [ConflictMotion](http://www.vim.org/scripts/script.php?script_id=3991) plugin. It reverted the yanked text so ConflictMotion got the wrong content. ConflictMotion tries to save, yank & return `@"` and restore to get the text to perserve.

I still don't know why this only breaks ConflictMotion, but after the fix everything seems fine.