### PR TITLE
Add .gitignore file with docs/tags & docs/tags-ja

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+doc/tags
+doc/tags-ja


### PR DESCRIPTION
I did this so that people can use git submodules to manage their vim
plugins and not have conflicts when the documentation tags are generated
by vim.